### PR TITLE
Update postcss-pxtorem to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "gulp-util": "^3.0.7",
     "postcss": "^5.0.14",
-    "postcss-pxtorem": "^3.3.1",
+    "postcss-pxtorem": "^4.0.1",
     "through2": "^2.0.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulpplugin"
   ],
   "devDependencies": {
-    "gulp-sourcemaps": "^1.6.0"
+    "gulp-sourcemaps": "^1.6.0",
+    "mocha": "^3.4.1"
   }
 }


### PR DESCRIPTION
This PR updates the `postcss-pxtorem` dependency to the latest version. Tests pass, nothing _seems_ to break.

It also tracks `mocha` as a dev dependency. This way it doesn’t have to be installed globally for `npm test` to work. :)